### PR TITLE
improve float cast precision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 
 # pytest
 .pytest_cache
+.build
 
 # Jupyter Notebook
 .ipynb_checkpoints

--- a/lib/fixedpointmath/fixedpointmath/fixed_point.py
+++ b/lib/fixedpointmath/fixedpointmath/fixed_point.py
@@ -567,9 +567,7 @@ class FixedPoint:
 
     def __float__(self) -> float:
         r"""Cast to float"""
-        if self.special_value is not None:
-            return float(self.special_value)
-        return float(self.scaled_value) / 10**self.decimal_places
+        return float(str(self))
 
     def __bool__(self) -> bool:
         r"""Cast to bool"""


### PR DESCRIPTION
the `str` cast already does all of the difficult work of assembling a "stringified" float that has precise precision, so we can lean on this to make float better.